### PR TITLE
Secure page handling

### DIFF
--- a/lib/cloudfront_asset_host.rb
+++ b/lib/cloudfront_asset_host.rb
@@ -81,6 +81,9 @@ module CloudfrontAssetHost
           host = cname.call(source, request)
         else
           host = (cname =~ /%d/) ? cname % (source.hash % 4) : cname.to_s
+
+          # Use relative URLs in CSS when cname is static
+          return "" if request === false && host == cname.to_s
           host = "#{protocol(request)}://#{host}"
         end
       else

--- a/lib/cloudfront_asset_host.rb
+++ b/lib/cloudfront_asset_host.rb
@@ -81,10 +81,10 @@ module CloudfrontAssetHost
           host = cname.call(source, request)
         else
           host = (cname =~ /%d/) ? cname % (source.hash % 4) : cname.to_s
-          host = "http://#{host}"
+          host = "#{protocol(request)}://#{host}"
         end
       else
-        host = "http://#{self.bucket_host}"
+        host = "#{protocol(request)}://#{self.bucket_host}"
       end
 
       if source && request && CloudfrontAssetHost.gzip
@@ -143,6 +143,14 @@ module CloudfrontAssetHost
     end
 
   private
+
+    def protocol(request)
+      if request.try(:ssl?) === true
+        "https"
+      else
+        "http"
+      end
+    end
 
     def properly_configured?
       raise "You'll need to specify a bucket" if bucket.blank?

--- a/lib/cloudfront_asset_host/css_rewriter.rb
+++ b/lib/cloudfront_asset_host/css_rewriter.rb
@@ -34,7 +34,7 @@ module CloudfrontAssetHost
 
           if path.present? && File.exists?(path)
             key = CloudfrontAssetHost.key_for_path(path) + path.gsub(Rails.public_path, '')
-            "url(#{CloudfrontAssetHost.asset_host(url)}/#{key})"
+            "url(/#{key})"
           else
             puts "Could not extract path: #{path}"
             asset_link

--- a/lib/cloudfront_asset_host/css_rewriter.rb
+++ b/lib/cloudfront_asset_host/css_rewriter.rb
@@ -34,7 +34,7 @@ module CloudfrontAssetHost
 
           if path.present? && File.exists?(path)
             key = CloudfrontAssetHost.key_for_path(path) + path.gsub(Rails.public_path, '')
-            "url(/#{key})"
+            "url(#{CloudfrontAssetHost.asset_host(url, false)}/#{key})"
           else
             puts "Could not extract path: #{path}"
             asset_link

--- a/test/cloudfront_asset_host_test.rb
+++ b/test/cloudfront_asset_host_test.rb
@@ -68,31 +68,37 @@ class CloudfrontAssetHostTest < Test::Unit::TestCase
       context "when taking the headers into account" do
 
         should "not support gzip for images" do
-          request = stub(:headers => {'User-Agent' => 'Mozilla/5.0', 'Accept-Encoding' => 'gzip, compress'})
+          request = stub(:headers => {'User-Agent' => 'Mozilla/5.0', 'Accept-Encoding' => 'gzip, compress'}, :ssl? => false)
           source  = "/images/logo.png"
           assert_equal "http://assethost.com", CloudfrontAssetHost.asset_host(source, request)
         end
 
         should "support gzip for IE" do
-          request = stub(:headers => {'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 8.0)', 'Accept-Encoding' => 'gzip, compress'})
+          request = stub(:headers => {'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 8.0)', 'Accept-Encoding' => 'gzip, compress'}, :ssl? => false)
           assert_equal "http://assethost.com/gz", CloudfrontAssetHost.asset_host(@source, request)
         end
 
         should "support gzip for modern browsers" do
-          request = stub(:headers => {'User-Agent' => 'Mozilla/5.0', 'Accept-Encoding' => 'gzip, compress'})
+          request = stub(:headers => {'User-Agent' => 'Mozilla/5.0', 'Accept-Encoding' => 'gzip, compress'}, :ssl? => false)
           assert_equal "http://assethost.com/gz", CloudfrontAssetHost.asset_host(@source, request)
         end
 
         should "support not support gzip for Netscape 4" do
-          request = stub(:headers => {'User-Agent' => 'Mozilla/4.0', 'Accept-Encoding' => 'gzip, compress'})
+          request = stub(:headers => {'User-Agent' => 'Mozilla/4.0', 'Accept-Encoding' => 'gzip, compress'}, :ssl? => false)
           assert_equal "http://assethost.com", CloudfrontAssetHost.asset_host(@source, request)
         end
 
         should "require gzip in accept-encoding" do
-          request = stub(:headers => {'User-Agent' => 'Mozilla/5.0'})
+          request = stub(:headers => {'User-Agent' => 'Mozilla/5.0'}, :ssl? => false)
           assert_equal "http://assethost.com", CloudfrontAssetHost.asset_host(@source, request)
         end
 
+        should "use https on secure request" do
+          request = stub(:headers => {'User-Agent' => 'Mozilla/5.0'}, :ssl? => true)
+          assert_equal "https://assethost.com", CloudfrontAssetHost.asset_host(@source, request)
+          CloudfrontAssetHost.cname = nil
+          assert_equal "https://bucketname.s3.amazonaws.com", CloudfrontAssetHost.asset_host(@source, request)
+        end
       end
 
     end

--- a/test/css_rewriter_test.rb
+++ b/test/css_rewriter_test.rb
@@ -23,6 +23,21 @@ class CssRewriterTest < Test::Unit::TestCase
       end
     end
 
+    should "use proc for url generation" do
+      CloudfrontAssetHost.configure do |config|
+        config.cname  = Proc.new { "http://assethost.com" }
+        config.bucket = "bucketname"
+        config.key_prefix = ""
+        config.enabled = false
+      end
+
+      tmp = CloudfrontAssetHost::CssRewriter.rewrite_stylesheet(@stylesheet_path)
+      contents = File.read(tmp.path)
+      contents.split("\n").each do |line|
+        assert_equal "body { background-image: url(http://assethost.com/d41d8cd98/images/image.png); }", line
+      end
+    end
+
   end
 
 end

--- a/test/css_rewriter_test.rb
+++ b/test/css_rewriter_test.rb
@@ -19,7 +19,7 @@ class CssRewriterTest < Test::Unit::TestCase
       tmp = CloudfrontAssetHost::CssRewriter.rewrite_stylesheet(@stylesheet_path)
       contents = File.read(tmp.path)
       contents.split("\n").each do |line|
-        assert_equal "body { background-image: url(http://assethost.com/d41d8cd98/images/image.png); }", line
+        assert_equal "body { background-image: url(/d41d8cd98/images/image.png); }", line
       end
     end
 

--- a/test/uploader_test.rb
+++ b/test/uploader_test.rb
@@ -130,7 +130,7 @@ class UploaderTest < Test::Unit::TestCase
       css_path = CloudfrontAssetHost::Uploader.rewritten_css_path(path)
 
       File.read(css_path).split("\n").each do |line|
-        assert_equal "body { background-image: url(http://assethost.com/d41d8cd98/images/image.png); }", line
+        assert_equal "body { background-image: url(/d41d8cd98/images/image.png); }", line
       end
     end
 


### PR DESCRIPTION
I'd like to have "lock icon" on pages while still serving resources from CDN. This is quite trivial and I implemented two changes to handle this situation:
- image URLs are relative which makes generated CSS protocol independent and saves few bytes on every url() definition
- asset host helper determines protocol using request object
