### PR TITLE
Rails 3 and some fixes for referencing SVG font files

### DIFF
--- a/lib/cloudfront_asset_host/asset_tag_helper_ext.rb
+++ b/lib/cloudfront_asset_host/asset_tag_helper_ext.rb
@@ -9,7 +9,7 @@ module ActionView
         if @@cache_asset_timestamps && (asset_id = @@asset_timestamps_cache[source])
           asset_id
         else
-          path = File.join(ASSETS_DIR, source)
+          path = File.join(config.assets_dir, source)
           rewrite_path = File.exist?(path) && !CloudfrontAssetHost.disable_cdn_for_source?(source)
           asset_id = rewrite_path ? CloudfrontAssetHost.key_for_path(path) : ''
 

--- a/lib/cloudfront_asset_host/asset_tag_helper_ext.rb
+++ b/lib/cloudfront_asset_host/asset_tag_helper_ext.rb
@@ -24,7 +24,7 @@ module ActionView
       end
 
       # Override asset_path so it prepends the asset_id
-      def rewrite_asset_path_with_cloudfront(source)
+      def rewrite_asset_path_with_cloudfront(source, path=nil)
         asset_id = rails_asset_id(source)
         if asset_id.blank?
           source

--- a/lib/cloudfront_asset_host/css_rewriter.rb
+++ b/lib/cloudfront_asset_host/css_rewriter.rb
@@ -9,7 +9,7 @@ module CloudfrontAssetHost
 
     class << self
       # matches optional quoted url(<path>)
-      ReplaceRexeg = /url\(["']?([^\)\?"']+)(\?[^"']*)?["']?\)/i
+      ReplaceRexeg = /url\(["']?([^\)\?\#"']+)(\#[^"']*)?(\?[^"']*)?["']?\)/i
 
       # Returns the path to the temporary file that contains the
       # rewritten stylesheet
@@ -28,12 +28,16 @@ module CloudfrontAssetHost
     private
 
       def rewrite_asset_link(asset_link, stylesheet_path)
-        url = asset_link.match(ReplaceRexeg)[1]
+        match = asset_link.match(ReplaceRexeg)[1]
+        url = match[1]
+        hash = match[2] || ''
+        query = match[3] || ''
+
         if url
           path = path_for_url(url, stylesheet_path)
 
           if path.present? && File.exists?(path)
-            key = CloudfrontAssetHost.key_for_path(path) + path.gsub(Rails.public_path, '')
+            key = CloudfrontAssetHost.key_for_path(path) + path.gsub(Rails.public_path, '') + hash + query
             "url(#{CloudfrontAssetHost.asset_host(url)}/#{key})"
           else
             puts "Could not extract path: #{path}"

--- a/lib/cloudfront_asset_host/css_rewriter.rb
+++ b/lib/cloudfront_asset_host/css_rewriter.rb
@@ -50,7 +50,7 @@ module CloudfrontAssetHost
       end
 
       def path_for_url(url, stylesheet_path)
-        if url.starts_with?('/')
+        if url.start_with?('/')
           # absolute to public path
           File.expand_path(File.join(Rails.public_path, url))
         else

--- a/lib/cloudfront_asset_host/css_rewriter.rb
+++ b/lib/cloudfront_asset_host/css_rewriter.rb
@@ -28,7 +28,7 @@ module CloudfrontAssetHost
     private
 
       def rewrite_asset_link(asset_link, stylesheet_path)
-        match = asset_link.match(ReplaceRexeg)[1]
+        match = asset_link.match(ReplaceRexeg)
         url = match[1]
         hash = match[2] || ''
         query = match[3] || ''


### PR DESCRIPTION
Rails 3 has an additional argument to 'rewrite_asset_path' so we need to add another argument.

Also, some SVG url() references in CSS files have hash parts, which reference a specific font in the SVG file, so we should assume that a hash in a CSS url() is not part of the resource filename.

What do you think?
